### PR TITLE
add a store for the Sequelize ORM

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ the api needs to return a Promise, Thunk, generator, or an async function.
 - [koa-pg-session](https://github.com/TMiguelT/koa-pg-session) to store your session data with PostgreSQL.
 - [koa-generic-session-rethinkdb](https://github.com/KualiCo/koa-generic-session-rethinkdb) to store your session data with ReThinkDB.
 - [koa-sqlite3-session](https://github.com/chichou/koa-sqlite3-session) to store your session data with SQLite3.
+- [koa-generic-session-sequelize](https://github.com/natesilva/koa-generic-session-sequelize) to store your session data with the [Sequelize](http://docs.sequelizejs.com/) ORM.
 
 
 # License


### PR DESCRIPTION
a new session store backed by Sequelize, that has been tested against SQLite, MySQL, PostgreSQL and SQL Server